### PR TITLE
.zoomImg fix when img has z-index and max-width

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -84,10 +84,12 @@
                 .addClass('zoomImg')
                 .css({
                     position: 'absolute',
+                    'z-index': 9999,
                     top: 0,
                     left: 0,
                     opacity: 0,
                     width: img.width,
+                    'max-width': img.width,
                     height: img.height,
                     border: 'none'
                 })


### PR DESCRIPTION
`.zoomImg` fix when `img` has `position` with `z-index` and `max-width: 100%`.
Other way the `.zoomImg` does not appear at all - it is under `.zoom img`.
