### PR TITLE
fix errors on IE8 because of img.style.left/top not available

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -75,8 +75,8 @@
 						top = 0;
 					}
 
-					img.style.left = (left * -xRatio) + 'px';
-					img.style.top = (top * -yRatio) + 'px';
+					$img.css('left', (left * -xRatio) + 'px');
+					$img.css('top', (top * -yRatio) + 'px');
 
 					e.preventDefault();
 				}


### PR DESCRIPTION
Hi there. Nice plugin. I fixed an error on IE8 real quick for you with this patch. I will send you a link to my site when it launches - your plugin works really well. Thanks.
