### PR TITLE
Destroyable

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -101,11 +101,13 @@
 
 					// Skip the fade-in for IE8 and lower since it chokes on fading-in
 					// and changing position based on mousemovement at the same time.
+					$(source).trigger("zoomedIn");
 					$img.stop()
 					.fadeTo($.support.opacity ? settings.duration : 0, 1);
 				}
 
 				function stop() {
+					$(source).trigger("zoomedOut");
 					$img.stop()
 					.fadeTo(settings.duration, 0);
 				}


### PR DESCRIPTION
So this is a great plugin! I'm using it in an image gallery and was getting hundreds of mouse events bound because it wasn't possible to destroy the previous events. I also needed to know when the plugin is zooming in and out.

Take your pick of both, either or neither of these features depending on what you like @jackmoore!
