### PR TITLE
Add data api support

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -82,7 +82,7 @@
 
 			// If a url wasn't specified, look for an image element.
 			if (!settings.url) {
-				settings.url = $(source).find('img').attr('src');
+				settings.url = $(source).find('img').data('src') ? $(source).find('img').data('src') : $(source).find('img').attr('src');
 				if (!settings.url) {
 					return;
 				}


### PR DESCRIPTION
Full image can be specified on the same source image via data-src
attribute

Fallback to src attribute or url setting if missing
