### PR TITLE
Reset position & overflow css on destroy.

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -216,7 +216,7 @@
 			img.src = settings.url;
 
 			$(source).one('zoom.destroy', function(){
-				$(source).off(".zoom");
+				$(source).off(".zoom").css({position: '',overflow: ''});
 				$img.remove();
 			});
 		});


### PR DESCRIPTION
Destroy event wasn't resetting position and overflow css parameters which were set by plugin.
Can be improved by saving 'before' parameters for this two css parameters, and then in destroy set them back to what they were.
Saves hours of headache :)
