### PR TITLE
Bug fix if destroy is called before image onload has finished.

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -116,6 +116,7 @@
 					target.style.position = position;
 					target.style.overflow = overflow;
 					$img.remove();
+					img.onload = null;
 				});
 				
 			}());


### PR DESCRIPTION
If destroy was called before the image onload was triggered, the onload function was still executed and appended the image to the page despite being destroyed.

This could cause many instances of the 'zoom' image to be appended undesirably, for example when initiating zoom on mouseover of thumbnails and destroying on mouseout.  If a user drags mouse across thumbnails, all zoom images would be appended to the page despite destroy being called on mouseout prior to the image loading.
