### PR TITLE
Replacing mouseenter by mouseover to emergent layers

### DIFF
--- a/jquery.zoom.js
+++ b/jquery.zoom.js
@@ -198,7 +198,7 @@
 					zoom.init(); // Preemptively call init because IE7 will fire the mousemove handler before the hover handler.
 
 					$source
-						.on('mouseenter.zoom', start)
+						.on('mouseover.zoom', start)
 						.on('mouseleave.zoom', stop)
 						.on(mousemove, zoom.move);
 				}


### PR DESCRIPTION
If the plugin is active in an emergent layer below the cursor, the event
mouseenter not work, because the cursor already within. For fix this,
you must replace the event mouseenter by mouseover.
